### PR TITLE
Don't use the user package DB in sandbox mode.

### DIFF
--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -138,8 +138,9 @@ cabalMiscOptions =
         sandboxConf = "cabal.sandbox.config"
         getSandboxDBs = do
           s <- readFile "cabal.sandbox.config"
-          return [packageDBFlag ++ " " ++ db | l <- lines s, "package-db:" `isPrefixOf` l
-                                               , let db = dropWhile isSpace $ drop (length "package-db:") l]
+          return $ "-no-user-package-db" :
+              [packageDBFlag ++ " " ++ db | l <- lines s, "package-db:" `isPrefixOf` l
+                                          , let db = dropWhile isSpace $ drop (length "package-db:") l]
 
 getBuildInfoOptions :: BuildInfo -> [String]
 getBuildInfoOptions bi = concat


### PR DESCRIPTION
This avoids spurious conflicts (which cabal sandbox itself avoids) when the same package is installed in both the user's package database and the sandbox's database.
